### PR TITLE
Fixed typo in args

### DIFF
--- a/create_submission.py
+++ b/create_submission.py
@@ -147,7 +147,7 @@ def main(args):
         )
         sys.exit(EXIT_CODE_OUTPUT_FILE_EXISTS)
 
-    scores_dict = load_results(args.scores_pt)
+    scores_dict = load_results(args.scores)
 
     if not verify_keys_are_present(scores_dict):
         sys.exit(EXIT_CODE_KEYS_NOT_PRESENT)


### PR DESCRIPTION
args have --scores but code uses args.scores_pt. Changed to scores in both cases as scores file is not always .pt

Fix for: https://github.com/epic-kitchens/C1-Action-Recognition/issues/1